### PR TITLE
Add Flutter web delivery calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
-# Codex
-Codex
+# Delivery App
+
+A simple Flutter web application for calculating delivery fees for three carriers.
+
+## Carriers
+- **Rouillon**: requires floor length and department.
+- **STTI**: requires floor length, department, and unloading option.
+- **Joyaux**: requires weight and department.
+
+The fee calculations currently use placeholder formulas. Replace them with the
+actual logic from your Excel files.
+
+## Getting Started
+1. Install [Flutter](https://docs.flutter.dev/get-started/install).
+2. Run `flutter pub get` inside `delivery_app`.
+3. To launch the web app:
+   ```bash
+   flutter run -d chrome
+   ```

--- a/delivery_app/lib/main.dart
+++ b/delivery_app/lib/main.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'pages/home_page.dart';
+
+void main() {
+  runApp(const DeliveryApp());
+}
+
+class DeliveryApp extends StatelessWidget {
+  const DeliveryApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Delivery Calculator',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: const HomePage(),
+    );
+  }
+}

--- a/delivery_app/lib/pages/home_page.dart
+++ b/delivery_app/lib/pages/home_page.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'rouillon_page.dart';
+import 'stti_page.dart';
+import 'joyaux_page.dart';
+
+class HomePage extends StatelessWidget {
+  const HomePage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Choisissez votre transporteur'),
+      ),
+      body: GridView.count(
+        padding: const EdgeInsets.all(16),
+        crossAxisCount: 2,
+        crossAxisSpacing: 16,
+        mainAxisSpacing: 16,
+        children: [
+          _logoTile(context, 'Rouillon', Icons.local_shipping, const RouillonPage()),
+          _logoTile(context, 'STTI', Icons.fire_truck, const SttiPage()),
+          _logoTile(context, 'Joyaux', Icons.local_mall, const JoyauxPage()),
+        ],
+      ),
+    );
+  }
+
+  Widget _logoTile(BuildContext context, String title, IconData icon, Widget page) {
+    return GestureDetector(
+      onTap: () => Navigator.of(context).push(
+        MaterialPageRoute(builder: (_) => page),
+      ),
+      child: Card(
+        elevation: 4,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(icon, size: 64),
+            const SizedBox(height: 12),
+            Text(title, style: const TextStyle(fontSize: 18)),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/delivery_app/lib/pages/joyaux_page.dart
+++ b/delivery_app/lib/pages/joyaux_page.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+
+class JoyauxPage extends StatefulWidget {
+  const JoyauxPage({Key? key}) : super(key: key);
+
+  @override
+  State<JoyauxPage> createState() => _JoyauxPageState();
+}
+
+class _JoyauxPageState extends State<JoyauxPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _weightController = TextEditingController();
+  final _departmentController = TextEditingController();
+
+  String? _result;
+
+  @override
+  void dispose() {
+    _weightController.dispose();
+    _departmentController.dispose();
+    super.dispose();
+  }
+
+  void _calculate() {
+    if (_formKey.currentState!.validate()) {
+      final weight = double.parse(_weightController.text);
+      final department = int.parse(_departmentController.text);
+      setState(() {
+        _result = 'Frais Joyaux: €${(weight * 1.2 + department).toStringAsFixed(2)}';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Joyaux')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              TextFormField(
+                controller: _weightController,
+                decoration: const InputDecoration(labelText: 'Poids (kg)'),
+                keyboardType: TextInputType.number,
+                validator: (value) => value == null || value.isEmpty ? 'Requis' : null,
+              ),
+              TextFormField(
+                controller: _departmentController,
+                decoration: const InputDecoration(labelText: 'Département'),
+                keyboardType: TextInputType.number,
+                validator: (value) => value == null || value.isEmpty ? 'Requis' : null,
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(onPressed: _calculate, child: const Text('Calculer')),
+              if (_result != null) ...[
+                const SizedBox(height: 16),
+                Text(_result!, style: const TextStyle(fontSize: 18)),
+              ]
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/delivery_app/lib/pages/rouillon_page.dart
+++ b/delivery_app/lib/pages/rouillon_page.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+
+class RouillonPage extends StatefulWidget {
+  const RouillonPage({Key? key}) : super(key: key);
+
+  @override
+  State<RouillonPage> createState() => _RouillonPageState();
+}
+
+class _RouillonPageState extends State<RouillonPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _lengthController = TextEditingController();
+  final _departmentController = TextEditingController();
+
+  String? _result;
+
+  @override
+  void dispose() {
+    _lengthController.dispose();
+    _departmentController.dispose();
+    super.dispose();
+  }
+
+  void _calculate() {
+    if (_formKey.currentState!.validate()) {
+      final length = double.parse(_lengthController.text);
+      final department = int.parse(_departmentController.text);
+      // TODO: Replace with lookup using Excel or your data source
+      setState(() {
+        _result = 'Frais Rouillon: €${(length * 0.5 + department).toStringAsFixed(2)}';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Rouillon')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              TextFormField(
+                controller: _lengthController,
+                decoration: const InputDecoration(labelText: 'Longueur plancher (m)'),
+                keyboardType: TextInputType.number,
+                validator: (value) => value == null || value.isEmpty ? 'Requis' : null,
+              ),
+              TextFormField(
+                controller: _departmentController,
+                decoration: const InputDecoration(labelText: 'Département'),
+                keyboardType: TextInputType.number,
+                validator: (value) => value == null || value.isEmpty ? 'Requis' : null,
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(onPressed: _calculate, child: const Text('Calculer')),
+              if (_result != null) ...[
+                const SizedBox(height: 16),
+                Text(_result!, style: const TextStyle(fontSize: 18)),
+              ]
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/delivery_app/lib/pages/stti_page.dart
+++ b/delivery_app/lib/pages/stti_page.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+
+class SttiPage extends StatefulWidget {
+  const SttiPage({Key? key}) : super(key: key);
+
+  @override
+  State<SttiPage> createState() => _SttiPageState();
+}
+
+class _SttiPageState extends State<SttiPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _lengthController = TextEditingController();
+  final _departmentController = TextEditingController();
+  bool _unloading = false;
+
+  String? _result;
+
+  @override
+  void dispose() {
+    _lengthController.dispose();
+    _departmentController.dispose();
+    super.dispose();
+  }
+
+  void _calculate() {
+    if (_formKey.currentState!.validate()) {
+      final length = double.parse(_lengthController.text);
+      final department = int.parse(_departmentController.text);
+      setState(() {
+        double base = length * 0.6 + department;
+        if (_unloading) base += 10.0;
+        _result = 'Frais STTI: €${base.toStringAsFixed(2)}';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('STTI')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              TextFormField(
+                controller: _lengthController,
+                decoration: const InputDecoration(labelText: 'Longueur plancher (m)'),
+                keyboardType: TextInputType.number,
+                validator: (value) => value == null || value.isEmpty ? 'Requis' : null,
+              ),
+              TextFormField(
+                controller: _departmentController,
+                decoration: const InputDecoration(labelText: 'Département'),
+                keyboardType: TextInputType.number,
+                validator: (value) => value == null || value.isEmpty ? 'Requis' : null,
+              ),
+              CheckboxListTile(
+                title: const Text('Option déchargement'),
+                value: _unloading,
+                onChanged: (val) => setState(() => _unloading = val ?? false),
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(onPressed: _calculate, child: const Text('Calculer')),
+              if (_result != null) ...[
+                const SizedBox(height: 16),
+                Text(_result!, style: const TextStyle(fontSize: 18)),
+              ]
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/delivery_app/pubspec.yaml
+++ b/delivery_app/pubspec.yaml
@@ -1,0 +1,18 @@
+name: delivery_app
+version: 1.0.0
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.1
+
+flutter:
+  uses-material-design: true
+  assets:
+    - assets/


### PR DESCRIPTION
## Summary
- implement simple Flutter web app in `delivery_app`
- add pages for Rouillon, STTI and Joyaux transporters with forms and dummy calculations
- document basic usage in the README

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406a9dd1cc833387422219971c48bd